### PR TITLE
event: add foo method for bar

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -564,6 +564,17 @@ to indicate an unlimited number of listeners.
 
 Returns a reference to the `EventEmitter`, so that calls can be chained.
 
+### emitter.foo([callback])
+<!-- YAML
+added: v8.0.0
+-->
+
+* `callback` {Function}
+
+Returns `'bar'` string synchronously if callback is omitted.
+When `callback` is specified, it is executed asynchronously and return `true`.
+The callback will receive the arguments `(err, 'bar')`. `err` is always `null`.
+
 [`net.Server`]: net.html#net_class_net_server
 [`fs.ReadStream`]: fs.html#fs_class_fs_readstream
 [`emitter.setMaxListeners(n)`]: #events_emitter_setmaxlisteners_n

--- a/lib/events.js
+++ b/lib/events.js
@@ -76,6 +76,17 @@ EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
   return $getMaxListeners(this);
 };
 
+EventEmitter.prototype.foo = function foo(callback) {
+  var err = null;
+  if (callback) {
+    process.nextTick(() => {
+      callback(err, 'bar');
+    });
+    return true;
+  }
+  return 'bar';
+};
+
 // These standalone emit* functions are used to optimize calling of event
 // handlers for fast cases because emit() itself often has a variable number of
 // arguments and can be deoptimized because of that. These functions always have

--- a/test/parallel/test-event-emitter-foo.js
+++ b/test/parallel/test-event-emitter-foo.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const EventEmitter = require('events');
+const assert = require('assert');
+
+const event1 = new EventEmitter();
+
+const bar = 'bar';
+
+// Sync API test
+assert.strictEqual(event1.foo(), bar);
+
+// Async API test
+const event2 = new EventEmitter();
+
+var ret = event2.foo(common.mustCall((err, arg) => {
+  assert.strictEqual(err, null);
+  assert.strictEqual(arg, bar);
+}));
+
+assert(ret);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j8 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

event

##### Description of change
<!-- Provide a description of the change below this comment. -->

foo() method is very important feature for bar. This api provide both
sync and async method. Async api is called if callback specified. The
callback is executed with arguments of an error of null and 'bar'.