### PR TITLE
doc: add and fix Errors API document.

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -463,6 +463,21 @@ referenced in `man 2 intro`. For example, an `ENOENT` error has an `errno` of
 
 Returns a string describing the [syscall][] that failed.
 
+#### error.address
+
+Returns a string describing the address that be not available.
+
+#### error.port
+
+Returns a number of the connection's port that refused (only when the port number is specified).
+
+For example:
+
+```js
+require('net').connect({port: 1234}).on('error', (err) => { console.error(err); });
+  // err will have the added properties of code, errno, syscall, address and port
+```
+
 ### Common System Errors
 
 This list is **not exhaustive**, but enumerates many of the common system

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -455,7 +455,7 @@ a sequence of capital letters, and may be referenced in `man 2 intro`.
 
 #### error.errno
 
-Returns a number corresponding to the **negated** error code, which may be
+Returns a number or a string corresponding to the **negated** error code, which may be
 referenced in `man 2 intro`. For example, an `ENOENT` error has an `errno` of
 `-2` because the error code for `ENOENT` is `2`.
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

1st commit:
In System Errors of Errors API, `error.address` and `error.port` are not described although being also represented as augmented Error objects with added properties by the following example.

https://github.com/nodejs/node/blob/v6.x-staging/lib/util.js#L1030-L1051

```
// with `address` and `port`  property
$node -e "require('net').connect({port: 100}).on('error', (err) => { console.error(err); });"
{ Error: connect ECONNREFUSED 127.0.0.1:100
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1087:14)
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 100 }

// with `address` property (without `port`  property)
$node -e "require('net').connect({host: 'localhost'}).on('error', (err) => { console.error(err); });"
{ Error: connect EADDRNOTAVAIL 127.0.0.1 - Local (0.0.0.0:54881)
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at connect (net.js:881:16)
    at net.js:1010:7
    at GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:62:16)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:81:10)
  code: 'EADDRNOTAVAIL',
  errno: 'EADDRNOTAVAIL',
  syscall: 'connect',
  address: '127.0.0.1' }
```

So, add their headers and descriptions.

2nd commit:
`error.errno` doesn't always return a number like the above example and the following code.

https://github.com/nodejs/node/blob/v6.x-staging/lib/util.js#L1024

So fix its description.