### PR TITLE
doc: add and fix System Error properties

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -250,21 +250,23 @@ not capture any frames.
 
 #### error.message
 
-Returns the string description of error as set by calling `new Error(message)`.
+The `error.message` property is the string description of error as set by calling
+`new Error(message)`.
 The `message` passed to the constructor will also appear in the first line of
 the stack trace of the `Error`, however changing this property after the
-`Error` object is created *may not* change the first line of the stack trace.
+`Error` object is created *may not* change the first line of the stack trace
+(for example, when error.stack is set before this property is changed).
 
 ```js
 const err = new Error('The message');
 console.log(err.message);
-  // Prints: The message
+// Prints: The message
 ```
 
 #### error.stack
 
-Returns a string describing the point in the code at which the `Error` was
-instantiated.
+The `error.stack` property is a string describing the point in the code at which
+the `Error` was instantiated.
 
 For example:
 
@@ -450,33 +452,34 @@ added properties.
 
 #### error.code
 
-Returns a string representing the error code, which is always `E` followed by
-a sequence of capital letters, and may be referenced in `man 2 intro`.
+The `error.code` property is a string representing the error code, which is always
+`E` followed by a sequence of capital letters.
 
 #### error.errno
 
-Returns a number or a string corresponding to the **negated** error code, which may be
-referenced in `man 2 intro`. For example, an `ENOENT` error has an `errno` of
-`-2` because the error code for `ENOENT` is `2`.
+The `error.errno` property is a number or a string.
+The number corresponds to the **negated** error code. For example, an `ENOENT`
+error has an `errno` of `-2` because the error code for `ENOENT` is `2`.
+In case of a string, it is the same as error.code.
 
 #### error.syscall
 
-Returns a string describing the [syscall][] that failed.
+The `error.syscall` property is a string describing the [syscall][] that failed.
+
+#### error.path
+
+When present (e.g. in `fs` or `child_process`), the `error.path` property is a string
+containing a relevant invalid pathname.
 
 #### error.address
 
-Returns a string describing the address that be not available.
+When present (e.g. in `net` or `dgram`), the `error.address` property is a string
+describing the address to which the connection failed.
 
 #### error.port
 
-Returns a number of the connection's port that refused (only when the port number is specified).
-
-For example:
-
-```js
-require('net').connect({port: 1234}).on('error', (err) => { console.error(err); });
-  // err will have the added properties of code, errno, syscall, address and port
-```
+When present (e.g. in `net` or `dgram`), the `error.port` property is a number of
+the connection's port that is not available.
 
 ### Common System Errors
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -463,6 +463,21 @@ referenced in `man 2 intro`. For example, an `ENOENT` error has an `errno` of
 
 Returns a string describing the [syscall][] that failed.
 
+#### error.address
+
+Returns a string describing the address that be not available.
+
+#### error.port
+
+Returns a number of the connection's port that refused (only when the port number is specified).
+
+For example:
+
+```js
+require('net').connect({port: 1234}).on('error', (err) => { console.error(err); });
+  // err will have the added properties of code, errno, syscall, address and port
+```
+
 ### Common System Errors
 
 This list is **not exhaustive**, but enumerates many of the common system

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -455,7 +455,7 @@ a sequence of capital letters, and may be referenced in `man 2 intro`.
 
 #### error.errno
 
-Returns a number corresponding to the **negated** error code, which may be
+Returns a number or a string corresponding to the **negated** error code, which may be
 referenced in `man 2 intro`. For example, an `ENOENT` error has an `errno` of
 `-2` because the error code for `ENOENT` is `2`.
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -255,7 +255,7 @@ The `error.message` property is the string description of error as set by callin
 The `message` passed to the constructor will also appear in the first line of
 the stack trace of the `Error`, however changing this property after the
 `Error` object is created *may not* change the first line of the stack trace
-(for example, when error.stack is set before this property is changed).
+(for example, when `error.stack` is set before this property is changed).
 
 ```js
 const err = new Error('The message');
@@ -460,7 +460,7 @@ The `error.code` property is a string representing the error code, which is alwa
 The `error.errno` property is a number or a string.
 The number corresponds to the **negated** error code. For example, an `ENOENT`
 error has an `errno` of `-2` because the error code for `ENOENT` is `2`.
-In case of a string, it is the same as error.code.
+In case of a string, it is the same as `error.code`.
 
 #### error.syscall
 


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc

##### Description of change

In System Errors properties of Errors API, `error.path`, `error.address` and `error.port` are not described although being also represented as augmented Error objects with added properties by the following code.

properties | link
--- | ---
address, port | https://github.com/nodejs/node/blob/v6.x-staging/lib/util.js#L1030-L1051
path | https://github.com/nodejs/node/blob/master/lib/child_process.js#L526

```
// examples
// with `path` property
$node -e "require('fs').readFile('a file that does not exist', (err, data) => { console.error(err); });"
{ Error: ENOENT: no such file or directory, open 'a file that does not exist'
    at Error (native)
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'a file that does not exist' }

// with `address` and `port` property
$node -e "require('net').connect({port: 100}).on('error', (err) => { console.error(err); });"
{ Error: connect ECONNREFUSED 127.0.0.1:100
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1087:14)
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 100 }

// with `address` property (without `port` property)
$node -e "require('net').connect({host: 'localhost'}).on('error', (err) => { console.error(err); });"
{ Error: connect EADDRNOTAVAIL 127.0.0.1 - Local (0.0.0.0:54881)
    at Object.exports._errnoException (util.js:1022:11)
    at exports._exceptionWithHostPort (util.js:1045:20)
    at connect (net.js:881:16)
    at net.js:1010:7
    at GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:62:16)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:81:10)
  code: 'EADDRNOTAVAIL',
  errno: 'EADDRNOTAVAIL',
  syscall: 'connect',
  address: '127.0.0.1' }
```

Also, `error.errno` doesn't always return a number like the above examples.
Please check the following code.

https://github.com/nodejs/node/blob/v6.x-staging/lib/util.js#L1024